### PR TITLE
Fix the build configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: 8
 
       - name: Run Gradle tasks


### PR DESCRIPTION
The actions/setup-java@v2 action requires `distribution` to be specified.