### PR TITLE
Specify reviewers for PRs created by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,9 @@
   "extends": [
     "config:base",
     ":automergeMinor"
+  ],
+  "reviewers": [
+    "Danil-Didkovskiy",
+    "vladimir-ikryanov"
   ]
 }


### PR DESCRIPTION
Fixes #10

With this configuration, the Renovate bot will request a review from the specified users when the automerge for PR is disabled (if PR updates the major version of the tool).