### PR TITLE
Check for version when resolving dependency notations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Gradle plug-in that provides convenience methods for adding JxBrowser dependen
 
 ```kotlin
 plugins {
-    id("com.teamdev.jxbrowser") version "1.0.0"
+    id("com.teamdev.jxbrowser") version "1.0.1"
 }
 
 jxbrowser {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 object BuildSettings {
     const val GROUP = "com.teamdev.jxbrowser"
-    const val VERSION = "1.0.0"
+    const val VERSION = "1.0.1"
     const val JXBROWSER_VERSION = "7.36"
     val javaVersion = JavaVersion.VERSION_1_8
 }

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -69,7 +69,7 @@ public open class JxBrowserExtension(private val project: Project) {
      * Returns a dependency notation for the `jxbrowser`,
      * an artifact with the core API of the library.
      */
-    public val core: Provider<String> = project.providers.provider { "$GROUP:jxbrowser:$version" }
+    public val core: Provider<String> = artifact("core")
 
     /**
      * Returns a dependency notation for the `jxbrowser-javafx`,
@@ -154,7 +154,14 @@ public open class JxBrowserExtension(private val project: Project) {
             }
     }
 
-    private fun artifact(shortName: String) = project.providers.provider { "$GROUP:jxbrowser-$shortName:$version" }
+    private fun artifact(shortName: String) = project.providers.provider {
+        check(version.isNotBlank()) { "JxBrowser version is not specified." }
+        if (shortName == "core") {
+            "$GROUP:jxbrowser:$version"
+        } else {
+            "$GROUP:jxbrowser-$shortName:$version"
+        }
+    }
 
     private companion object {
         private const val GROUP = "com.teamdev.jxbrowser"

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPlugin.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPlugin.kt
@@ -55,7 +55,6 @@ public class JxBrowserPlugin : Plugin<Project> {
         val extension = project.extensions.create(EXTENSION_NAME, JxBrowserExtension::class.java, project)
         project.addMavenRepositoryLocation(project.providers.provider { extension.repository })
         project.afterEvaluate {
-            check(extension.version.isNotBlank()) { "JxBrowser version is not specified." }
             if (extension.includePreviewBuilds) {
                 project.addMavenRepositoryLocation(EAP_REPOSITORY_URL)
             }

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -43,7 +43,6 @@ internal class JxBrowserPluginTest {
         project = ProjectBuilder.builder().build()
         project.pluginManager.apply(pluginId)
         extension = project.extensions.getByType(JxBrowserExtension::class.java)
-        extension.version = jxBrowserVersion
     }
 
     @Test
@@ -56,6 +55,7 @@ internal class JxBrowserPluginTest {
     @Test
     fun `resolve dependencies`() {
         with(extension) {
+            version = jxBrowserVersion
             val group = "com.teamdev.jxbrowser"
 
             swt.get() shouldBe "$group:jxbrowser-swt:$jxBrowserVersion"


### PR DESCRIPTION
Previously we checked for the JxBrowser version right after the plugin was applied and could see the ISE in the console at this stage: 

```kotlin
 id("com.teamdev.jxbrowser") version "1.0.1"
```

Because of this, we can't configure the plugin extension with IDEA hints, as everything breaks at the stage of applying the plugin.

In this PR, we do JxBrowser version checking while resolving dependency notations, not when applying the plugin.