### PR TITLE
Disable Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":automergeMinor"
+    ":automergeMinor",
+    ":disableDependencyDashboard"
   ],
   "reviewers": [
     "Danil-Didkovskiy",


### PR DESCRIPTION
In this PR we prevent the Renovate bot from creating a [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) issue in this repository.