### PR TITLE
Add support for Kotlin and Compose Maven artifacts

### DIFF
--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -71,6 +71,18 @@ public open class JxBrowserExtension(private val project: Project) {
     public val core: Provider<String> = artifact("core")
 
     /**
+     * Returns a dependency notation for the `jxbrowser-kotlin`,
+     * an artifact with the Kotlin API of the library.
+     */
+    public val kotlin: Provider<String> = artifact("kotlin")
+
+    /**
+     * Returns a dependency notation for the `jxbrowser-compose`,
+     * an artifact with Compose integration.
+     */
+    public val compose: Provider<String> = artifact("compose")
+
+    /**
      * Returns a dependency notation for the `jxbrowser-javafx`,
      * an artifact with JavaFX integration.
      */

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -125,7 +125,60 @@ internal class JxBrowserPluginFunctionalTest {
             
             tasks.register<Copy>("$taskName") {
                 from(configurations.getByName("toCopy"))
-                into("$libsFolder")
+                into("${libsFolder.toString().replace("\\", "/")}")
+            }
+            """.trimIndent(),
+        )
+
+        val result =
+            GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withPluginClasspath()
+                .withArguments(taskName)
+                .build()
+
+        result.outcome(":$taskName") shouldBe SUCCESS
+        libsFolder.files() shouldContainExactlyInAnyOrder filesToCheck
+    }
+
+    @Test
+    fun `download JxBrowser 8 jars`() {
+        val taskName = "downloadJars"
+        val jxBrowserVersion = "8.0.0-eap.1"
+        val filesToCheck =
+            listOf(
+                "jxbrowser-$jxBrowserVersion.jar",
+                "jxbrowser-kotlin-$jxBrowserVersion.jar",
+                "jxbrowser-compose-$jxBrowserVersion.jar",
+                "jxbrowser-swing-$jxBrowserVersion.jar",
+            )
+
+        buildFile.writeText(
+            """ 
+            plugins {
+                base
+                id("com.teamdev.jxbrowser")
+            }
+            
+            jxbrowser {
+                version = "$jxBrowserVersion"
+                includePreviewBuilds()
+            }
+            
+            configurations {
+                create("toCopy")
+            }
+            
+            dependencies {
+                "toCopy"(jxbrowser.core)
+                "toCopy"(jxbrowser.kotlin)
+                "toCopy"(jxbrowser.compose)
+                "toCopy"(jxbrowser.swing)
+            }
+            
+            tasks.register<Copy>("$taskName") {
+                from(configurations.getByName("toCopy"))
+                into("${libsFolder.toString().replace("\\", "/")}")
             }
             """.trimIndent(),
         )


### PR DESCRIPTION
This changeset extends the plugin API to allow configuring dependencies to the Kotlin and Compose Maven artifacts.