### PR TITLE
Add compose to the list of supported UI toolkits

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ dependencies {
     implementation(jxbrowser.swt)
     implementation(jxbrowser.swing)
     implementation(jxbrowser.javafx)
+    implementation(jxbrowser.compose)
 
     // Detects the current platform and adds the corresponding Chromium binaries.
     implementation(jxbrowser.currentPlatform)


### PR DESCRIPTION
This PR updates `Readme.md` file to show how to add `compose` dependency to the Gradle project.