### PR TITLE
Support Windows ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dependencies {
     implementation(jxbrowser.macArm)
     implementation(jxbrowser.win32)
     implementation(jxbrowser.win64)
+    implementation(jxbrowser.winArm64)
     implementation(jxbrowser.linux64)
     implementation(jxbrowser.linuxArm)
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dependencies {
     implementation(jxbrowser.macArm)
     implementation(jxbrowser.win32)
     implementation(jxbrowser.win64)
-    implementation(jxbrowser.winArm64)
+    implementation(jxbrowser.win64Arm)
     implementation(jxbrowser.linux64)
     implementation(jxbrowser.linuxArm)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
+    implementation("com.vdurmont:semver4j:3.1.0")
 
     testImplementation(kotlin("test"))
     testImplementation(gradleTestKit())

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -115,6 +115,8 @@ public open class JxBrowserExtension(private val project: Project) {
     /**
      * Returns a dependency notation for the `jxbrowser-win64-arm`,
      * an artifact with Chromium Windows ARM 64-bit binaries.
+     *
+     * As for now, Windows ARM is only supported in JxBrowser 8.x.x.
      */
     public val win64Arm: Provider<String> = artifact("win64-arm")
 
@@ -179,6 +181,9 @@ public open class JxBrowserExtension(private val project: Project) {
     private fun artifact(shortName: String) =
         project.providers.provider {
             check(version.isNotBlank()) { "JxBrowser version is not specified." }
+            check(!(!version.startsWith("8") && shortName.equals("win64-arm"))) {
+                "Windows ARM is not supported in JxBrowser $version. Use 8.x.x."
+            }
             if (shortName == "core") {
                 "$GROUP:jxbrowser:$version"
             } else {

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -191,11 +191,12 @@ public open class JxBrowserExtension(private val project: Project) {
      * Check if the artifact with `shortName` exists in JxBrowser `version`.
      */
     private fun checkArtifactSupported(shortName: String) {
-        val artifactNameToReleaseVersion = mapOf(
-            "compose" to "8.0.0-eap.1",
-            "kotlin" to "8.0.0-eap1",
-            "win64-arm" to "8.0.0",
-        )
+        val artifactNameToReleaseVersion =
+            mapOf(
+                "compose" to "8.0.0-eap.1",
+                "kotlin" to "8.0.0-eap.1",
+                "win64-arm" to "8.0.0",
+            )
         val possibleReleaseVersion = artifactNameToReleaseVersion[shortName]
         if (possibleReleaseVersion != null) {
             val releaseVersion = Semver(possibleReleaseVersion)

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -113,6 +113,12 @@ public open class JxBrowserExtension(private val project: Project) {
     public val win32: Provider<String> = artifact("win32")
 
     /**
+     * Returns a dependency notation for the `jxbrowser-win-arm64`,
+     * an artifact with Chromium Windows ARM 64-bit binaries.
+     */
+    public val winArm64: Provider<String> = artifact("win-arm64")
+
+    /**
      * Returns a dependency notation for the `jxbrowser-linux64`,
      * an artifact with Chromium Linux 64-bit binaries.
      */
@@ -152,6 +158,7 @@ public open class JxBrowserExtension(private val project: Project) {
         val platformMap =
             mapOf(
                 Pair({ isX64Bit() && isWindows() }, win64),
+                Pair({ isArm() && isWindows() }, winArm64),
                 Pair({ isX64Bit() && isLinux() }, linux64),
                 Pair({ isX64Bit() && isMac() }, mac),
                 Pair({ is32Bit() && isWindows() }, win32),

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -74,12 +74,16 @@ public open class JxBrowserExtension(private val project: Project) {
     /**
      * Returns a dependency notation for the `jxbrowser-kotlin`,
      * an artifact with the Kotlin API of the library.
+     *
+     * Kotlin API is only supported in JxBrowser 8.x.x.
      */
     public val kotlin: Provider<String> = artifact("kotlin")
 
     /**
      * Returns a dependency notation for the `jxbrowser-compose`,
      * an artifact with Compose integration.
+     *
+     * Compose is only supported in JxBrowser 8.x.x.
      */
     public val compose: Provider<String> = artifact("compose")
 
@@ -117,7 +121,7 @@ public open class JxBrowserExtension(private val project: Project) {
      * Returns a dependency notation for the `jxbrowser-win64-arm`,
      * an artifact with Chromium Windows ARM 64-bit binaries.
      *
-     * As for now, Windows ARM is only supported in JxBrowser 8.x.x.
+     * Windows ARM is only supported in JxBrowser 8.x.x.
      */
     public val win64Arm: Provider<String> = artifact("win64-arm")
 

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -113,10 +113,10 @@ public open class JxBrowserExtension(private val project: Project) {
     public val win32: Provider<String> = artifact("win32")
 
     /**
-     * Returns a dependency notation for the `jxbrowser-win-arm64`,
+     * Returns a dependency notation for the `jxbrowser-win64-arm`,
      * an artifact with Chromium Windows ARM 64-bit binaries.
      */
-    public val winArm64: Provider<String> = artifact("win-arm64")
+    public val winArm64: Provider<String> = artifact("win64-arm")
 
     /**
      * Returns a dependency notation for the `jxbrowser-linux64`,

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -201,12 +201,12 @@ public open class JxBrowserExtension(private val project: Project) {
                 "kotlin" to "8.0.0-eap.1",
                 "win64-arm" to "8.0.0",
             )
-        val possibleReleaseVersion = artifactNameToReleaseVersion[shortName]
-        if (possibleReleaseVersion != null) {
-            val releaseVersion = Semver(possibleReleaseVersion)
+        val artifactReleaseVersion = artifactNameToReleaseVersion[shortName]
+        if (artifactReleaseVersion != null) {
+            val releaseVersion = Semver(artifactReleaseVersion)
             val actualVersion = Semver(version)
             check(actualVersion.isGreaterThanOrEqualTo(releaseVersion)) {
-                "Artifact '$shortName' is not supported by JxBrowser $version. Use $possibleReleaseVersion or greater."
+                "Artifact '$shortName' is not supported by JxBrowser $version. Use $artifactReleaseVersion or greater."
             }
         }
     }

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -116,7 +116,7 @@ public open class JxBrowserExtension(private val project: Project) {
      * Returns a dependency notation for the `jxbrowser-win64-arm`,
      * an artifact with Chromium Windows ARM 64-bit binaries.
      */
-    public val winArm64: Provider<String> = artifact("win64-arm")
+    public val win64Arm: Provider<String> = artifact("win64-arm")
 
     /**
      * Returns a dependency notation for the `jxbrowser-linux64`,
@@ -156,15 +156,18 @@ public open class JxBrowserExtension(private val project: Project) {
 
     private fun currentPlatform(): Provider<String> {
         val platformMap =
-            mapOf(
+            mutableMapOf(
                 Pair({ isX64Bit() && isWindows() }, win64),
-                Pair({ isArm() && isWindows() }, winArm64),
                 Pair({ isX64Bit() && isLinux() }, linux64),
                 Pair({ isX64Bit() && isMac() }, mac),
                 Pair({ is32Bit() && isWindows() }, win32),
                 Pair({ isArm() && isLinux() }, linuxArm),
                 Pair({ isArm() && isMac() }, macArm),
             )
+        if (version.startsWith("8")) {
+            // As for now, Windows ARM is only supported in JxBrowser 8.
+            platformMap[{isArm() && isWindows()}] = win64Arm
+        }
         return platformMap.entries.firstOrNull { it.key() }?.value
             ?: project.providers.provider {
                 val currentPlatform = "${osName()} ${jvmArch()}"

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -157,16 +157,16 @@ public open class JxBrowserExtension(private val project: Project) {
     private fun currentPlatform(): Provider<String> {
         val platformMap =
             mutableMapOf(
-                Pair({ isX64Bit() && isWindows() }, win64),
-                Pair({ isX64Bit() && isLinux() }, linux64),
-                Pair({ isX64Bit() && isMac() }, mac),
-                Pair({ is32Bit() && isWindows() }, win32),
-                Pair({ isArm() && isLinux() }, linuxArm),
-                Pair({ isArm() && isMac() }, macArm),
+                { isX64Bit() && isWindows() } to win64,
+                { isX64Bit() && isLinux() } to linux64,
+                { isX64Bit() && isMac() } to mac,
+                { is32Bit() && isWindows() } to win32,
+                { isArm() && isLinux() } to linuxArm,
+                { isArm() && isMac() } to macArm,
             )
         if (version.startsWith("8")) {
             // As for now, Windows ARM is only supported in JxBrowser 8.
-            platformMap[{isArm() && isWindows()}] = win64Arm
+            platformMap.put({ isArm() && isWindows() }, win64Arm)
         }
         return platformMap.entries.firstOrNull { it.key() }?.value
             ?: project.providers.provider {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -202,19 +202,19 @@ internal class JxBrowserPluginFunctionalTest {
         for (artifact in unsupportedArtifacts) {
             buildFile.writeText(
                 """ 
-            plugins {
-                java
-                id("com.teamdev.jxbrowser")
-            }
-            
-            jxbrowser {
-                version = "$jxBrowserVersion"
-            }
-            
-            dependencies {
-                implementation(jxbrowser.$artifact)
-            }
-            """.trimIndent(),
+                plugins {
+                    java
+                    id("com.teamdev.jxbrowser")
+                }
+                
+                jxbrowser {
+                    version = "$jxBrowserVersion"
+                }
+                
+                dependencies {
+                    implementation(jxbrowser.$artifact)
+                }
+                """.trimIndent(),
             )
 
             assertFails {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -82,20 +82,22 @@ internal class JxBrowserPluginFunctionalTest {
     fun `download JxBrowser jars`() {
         val taskName = "downloadJars"
         val filesToCheck =
-            listOf(
+            mutableListOf(
                 "jxbrowser-$jxBrowserVersion.jar",
                 "jxbrowser-javafx-$jxBrowserVersion.jar",
                 "jxbrowser-swing-$jxBrowserVersion.jar",
                 "jxbrowser-swt-$jxBrowserVersion.jar",
                 "jxbrowser-win64-$jxBrowserVersion.jar",
                 "jxbrowser-win32-$jxBrowserVersion.jar",
-                "jxbrowser-win-arm64-$jxBrowserVersion.jar",
                 "jxbrowser-linux64-$jxBrowserVersion.jar",
                 "jxbrowser-linux64-arm-$jxBrowserVersion.jar",
                 "jxbrowser-mac-$jxBrowserVersion.jar",
                 "jxbrowser-mac-arm-$jxBrowserVersion.jar",
             )
-
+        if (jxBrowserVersion.startsWith("8")) {
+            // As for now, Windows ARM is only supported in JxBrowser 8.
+            filesToCheck.add("jxbrowser-win64-arm-$jxBrowserVersion.jar")
+        }
         buildFile.writeText(
             """ 
             plugins {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -89,6 +89,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "jxbrowser-swt-$jxBrowserVersion.jar",
                 "jxbrowser-win64-$jxBrowserVersion.jar",
                 "jxbrowser-win32-$jxBrowserVersion.jar",
+                "jxbrowser-win-arm64-$jxBrowserVersion.jar",
                 "jxbrowser-linux64-$jxBrowserVersion.jar",
                 "jxbrowser-linux64-arm-$jxBrowserVersion.jar",
                 "jxbrowser-mac-$jxBrowserVersion.jar",
@@ -119,6 +120,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.macArm)
                 "toCopy"(jxbrowser.win32)
                 "toCopy"(jxbrowser.win64)
+                "toCopy"(jxbrowser.winArm64)
                 "toCopy"(jxbrowser.linux64)
                 "toCopy"(jxbrowser.linuxArm)
             }

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -121,8 +121,10 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.mac)
                 "toCopy"(jxbrowser.macArm)
                 "toCopy"(jxbrowser.win32)
+                if ("$jxBrowserVersion".startsWith("8")) {
+                  "toCopy"(jxbrowser.win64Arm) 
+                }
                 "toCopy"(jxbrowser.win64)
-                "toCopy"(jxbrowser.winArm64)
                 "toCopy"(jxbrowser.linux64)
                 "toCopy"(jxbrowser.linuxArm)
             }

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -82,7 +82,7 @@ internal class JxBrowserPluginFunctionalTest {
     fun `download JxBrowser jars`() {
         val taskName = "downloadJars"
         val filesToCheck =
-            mutableListOf(
+            listOf(
                 "jxbrowser-$jxBrowserVersion.jar",
                 "jxbrowser-javafx-$jxBrowserVersion.jar",
                 "jxbrowser-swing-$jxBrowserVersion.jar",
@@ -94,10 +94,6 @@ internal class JxBrowserPluginFunctionalTest {
                 "jxbrowser-mac-$jxBrowserVersion.jar",
                 "jxbrowser-mac-arm-$jxBrowserVersion.jar",
             )
-        if (jxBrowserVersion.startsWith("8")) {
-            // As for now, Windows ARM is only supported in JxBrowser 8.
-            filesToCheck.add("jxbrowser-win64-arm-$jxBrowserVersion.jar")
-        }
         buildFile.writeText(
             """ 
             plugins {
@@ -121,9 +117,6 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.mac)
                 "toCopy"(jxbrowser.macArm)
                 "toCopy"(jxbrowser.win32)
-                if ("$jxBrowserVersion".startsWith("8")) {
-                  "toCopy"(jxbrowser.win64Arm) 
-                }
                 "toCopy"(jxbrowser.win64)
                 "toCopy"(jxbrowser.linux64)
                 "toCopy"(jxbrowser.linuxArm)
@@ -157,6 +150,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "jxbrowser-kotlin-$jxBrowserVersion.jar",
                 "jxbrowser-compose-$jxBrowserVersion.jar",
                 "jxbrowser-swing-$jxBrowserVersion.jar",
+                "jxbrowser-win64-arm-$jxBrowserVersion.jar",
             )
 
         buildFile.writeText(
@@ -180,6 +174,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.kotlin)
                 "toCopy"(jxbrowser.compose)
                 "toCopy"(jxbrowser.swing)
+                "toCopy"(jxbrowser.win64Arm)
             }
             
             tasks.register<Copy>("$taskName") {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -24,7 +24,6 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.io.TempDir

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -63,6 +63,7 @@ internal class JxBrowserPluginTest {
             swing.get() shouldBe "$group:jxbrowser-swing:$jxBrowserVersion"
             win32.get() shouldBe "$group:jxbrowser-win32:$jxBrowserVersion"
             win64.get() shouldBe "$group:jxbrowser-win64:$jxBrowserVersion"
+            winArm64.get() shouldBe "$group:jxbrowser-win-arm64:$jxBrowserVersion"
             javafx.get() shouldBe "$group:jxbrowser-javafx:$jxBrowserVersion"
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"
             linux64.get() shouldBe "$group:jxbrowser-linux64:$jxBrowserVersion"

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -63,7 +63,10 @@ internal class JxBrowserPluginTest {
             swing.get() shouldBe "$group:jxbrowser-swing:$jxBrowserVersion"
             win32.get() shouldBe "$group:jxbrowser-win32:$jxBrowserVersion"
             win64.get() shouldBe "$group:jxbrowser-win64:$jxBrowserVersion"
-            winArm64.get() shouldBe "$group:jxbrowser-win-arm64:$jxBrowserVersion"
+            if (jxBrowserVersion.startsWith("8")) {
+                // As for now, Windows ARM is only supported in JxBrowser 8.
+                winArm64.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
+            }
             javafx.get() shouldBe "$group:jxbrowser-javafx:$jxBrowserVersion"
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"
             linux64.get() shouldBe "$group:jxbrowser-linux64:$jxBrowserVersion"

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -63,10 +63,6 @@ internal class JxBrowserPluginTest {
             swing.get() shouldBe "$group:jxbrowser-swing:$jxBrowserVersion"
             win32.get() shouldBe "$group:jxbrowser-win32:$jxBrowserVersion"
             win64.get() shouldBe "$group:jxbrowser-win64:$jxBrowserVersion"
-            if (jxBrowserVersion.startsWith("8")) {
-                // As for now, Windows ARM is only supported in JxBrowser 8.
-                win64Arm.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
-            }
             javafx.get() shouldBe "$group:jxbrowser-javafx:$jxBrowserVersion"
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"
             linux64.get() shouldBe "$group:jxbrowser-linux64:$jxBrowserVersion"

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -65,7 +65,7 @@ internal class JxBrowserPluginTest {
             win64.get() shouldBe "$group:jxbrowser-win64:$jxBrowserVersion"
             if (jxBrowserVersion.startsWith("8")) {
                 // As for now, Windows ARM is only supported in JxBrowser 8.
-                winArm64.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
+                win64Arm.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
             }
             javafx.get() shouldBe "$group:jxbrowser-javafx:$jxBrowserVersion"
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"


### PR DESCRIPTION
In this changeset, we add a dependency to Windows ARM binaries since we recently [introduced](https://github.com/TeamDev-IP/JxBrowser/issues/2990) the support of this architecture. As for now, this will only be supported in JxBrowser 8.

Also, I added a check for some artifacts supported only in JxBrowser 8. From now on, if the user decides to use the `jxbrowser-kotlin` artifact with JxBrowser 7, for example, the build will fail.