### PR TITLE
Add the dependency for Kotlin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ dependencies {
     implementation(jxbrowser.swing)
     implementation(jxbrowser.javafx)
     implementation(jxbrowser.compose)
+
+    // Adds dependency to the JxBrowser Kotlin DSL.
+    implementation(jxbrowser.kotlin)
 }
 ```
 


### PR DESCRIPTION
In this changeset, I have updated `README.md` to show how to include the dependencies for Kotlin DSL.

Issue: TeamDev-IP/JxBrowser-Docs#2269