### PR TITLE
Add GraalVM Native Image artifact support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 object BuildSettings {
     const val GROUP = "com.teamdev.jxbrowser"
     const val VERSION = "2.0.0"
-    const val JXBROWSER_VERSION = "8.18.3"
+    const val JXBROWSER_VERSION = "9.0.0"
     val javaVersion = JavaVersion.VERSION_1_8
 }
 

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -118,10 +118,10 @@ public open class JxBrowserExtension(
     public val swt: Provider<String> = artifact("swt")
 
     /**
-     * Returns a dependency notation for the `jxbrowser-graalvm`,
-     * an artifact containing GraalVM reachability metadata configuration.
+     * Returns a dependency notation for the `jxbrowser-native-image`,
+     * an artifact containing GraalVM Native Image reachability metadata configuration.
      */
-    public val graalvm: Provider<String> = artifact("graalvm")
+    public val nativeImage: Provider<String> = artifact("native-image")
 
     /**
      * Returns a dependency notation for the `jxbrowser-win64`,

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -216,12 +216,6 @@ public open class JxBrowserExtension(
         shortName: String,
         version: String,
     ) {
-        val artifactNameToReleaseVersion =
-            mapOf(
-                "compose" to "8.0.0",
-                "kotlin" to "8.0.0",
-                "win64-arm" to "8.0.0",
-            )
         val artifactReleaseVersion = artifactNameToReleaseVersion[shortName]
         if (artifactReleaseVersion != null) {
             val releaseVersion = Semver(artifactReleaseVersion)
@@ -234,5 +228,16 @@ public open class JxBrowserExtension(
 
     private companion object {
         private const val GROUP = "com.teamdev.jxbrowser"
+
+        /**
+         * Maps an artifact short name to the first JxBrowser version that supports it.
+         */
+        private val artifactNameToReleaseVersion =
+            mapOf(
+                "compose" to "8.0.0",
+                "kotlin" to "8.0.0",
+                "win64-arm" to "8.0.0",
+                "native-image" to "9.0.0",
+            )
     }
 }

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -119,7 +119,7 @@ public open class JxBrowserExtension(
 
     /**
      * Returns a dependency notation for the `jxbrowser-native-image`,
-     * an artifact containing GraalVM Native Image reachability metadata configuration.
+     * an artifact containing GraalVM Native Image reachability metadata.
      */
     public val nativeImage: Provider<String> = artifact("native-image")
 

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -118,6 +118,12 @@ public open class JxBrowserExtension(
     public val swt: Provider<String> = artifact("swt")
 
     /**
+     * Returns a dependency notation for the `jxbrowser-graalvm`,
+     * an artifact containing GraalVM reachability metadata configuration.
+     */
+    public val graalvm: Provider<String> = artifact("graalvm")
+
+    /**
      * Returns a dependency notation for the `jxbrowser-win64`,
      * an artifact with Chromium Windows 64-bit binaries.
      */

--- a/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserExtension.kt
@@ -87,7 +87,7 @@ public open class JxBrowserExtension(
      * Returns a dependency notation for the `jxbrowser-kotlin`,
      * an artifact with the Kotlin API of the library.
      *
-     * Kotlin API is only supported in JxBrowser 8.x.x.
+     * Kotlin API is only supported in JxBrowser 8.x.x and newer.
      */
     public val kotlin: Provider<String> = artifact("kotlin")
 
@@ -95,7 +95,7 @@ public open class JxBrowserExtension(
      * Returns a dependency notation for the `jxbrowser-compose`,
      * an artifact with Compose integration.
      *
-     * Compose is only supported in JxBrowser 8.x.x.
+     * Compose is only supported in JxBrowser 8.x.x and newer.
      */
     public val compose: Provider<String> = artifact("compose")
 
@@ -120,6 +120,8 @@ public open class JxBrowserExtension(
     /**
      * Returns a dependency notation for the `jxbrowser-native-image`,
      * an artifact containing GraalVM Native Image reachability metadata.
+     *
+     * Native images are only supported in JxBrowser 9.x.x and newer.
      */
     public val nativeImage: Provider<String> = artifact("native-image")
 
@@ -234,9 +236,9 @@ public open class JxBrowserExtension(
          */
         private val artifactNameToReleaseVersion =
             mapOf(
-                "compose" to "8.0.0",
-                "kotlin" to "8.0.0",
-                "win64-arm" to "8.0.0",
+                "compose" to "9.0.0",
+                "kotlin" to "9.0.0",
+                "win64-arm" to "9.0.0",
                 "native-image" to "9.0.0",
             )
     }

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -99,7 +99,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "jxbrowser-kotlin-$jxBrowserVersion.jar",
                 "jxbrowser-compose-$jxBrowserVersion.jar",
                 "jxbrowser-win64-arm-$jxBrowserVersion.jar",
-                "jxbrowser-graalvm-$jxBrowserVersion.jar",
+                "jxbrowser-native-image-$jxBrowserVersion.jar",
             )
         buildFile.writeText(
             """ 
@@ -130,7 +130,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.kotlin)
                 "toCopy"(jxbrowser.compose)
                 "toCopy"(jxbrowser.winArm)
-                "toCopy"(jxbrowser.graalvm)
+                "toCopy"(jxbrowser.nativeImage)
             }
             
             tasks.register<Copy>("$taskName") {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginFunctionalTest.kt
@@ -99,6 +99,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "jxbrowser-kotlin-$jxBrowserVersion.jar",
                 "jxbrowser-compose-$jxBrowserVersion.jar",
                 "jxbrowser-win64-arm-$jxBrowserVersion.jar",
+                "jxbrowser-graalvm-$jxBrowserVersion.jar",
             )
         buildFile.writeText(
             """ 
@@ -129,6 +130,7 @@ internal class JxBrowserPluginFunctionalTest {
                 "toCopy"(jxbrowser.kotlin)
                 "toCopy"(jxbrowser.compose)
                 "toCopy"(jxbrowser.winArm)
+                "toCopy"(jxbrowser.graalvm)
             }
             
             tasks.register<Copy>("$taskName") {

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -67,10 +67,10 @@ internal class JxBrowserPluginTest {
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"
             kotlin.get() shouldBe "$group:jxbrowser-kotlin:$jxBrowserVersion"
             winArm.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
-            graalvm.get() shouldBe "$group:jxbrowser-graalvm:$jxBrowserVersion"
             compose.get() shouldBe "$group:jxbrowser-compose:$jxBrowserVersion"
             linux64.get() shouldBe "$group:jxbrowser-linux64:$jxBrowserVersion"
             linuxArm.get() shouldBe "$group:jxbrowser-linux64-arm:$jxBrowserVersion"
+            nativeImage.get() shouldBe "$group:jxbrowser-native-image:$jxBrowserVersion"
             crossPlatform.get() shouldBe "$group:jxbrowser-cross-platform:$jxBrowserVersion"
         }
     }

--- a/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
+++ b/src/test/kotlin/com/teamdev/jxbrowser/gradle/JxBrowserPluginTest.kt
@@ -67,6 +67,7 @@ internal class JxBrowserPluginTest {
             macArm.get() shouldBe "$group:jxbrowser-mac-arm:$jxBrowserVersion"
             kotlin.get() shouldBe "$group:jxbrowser-kotlin:$jxBrowserVersion"
             winArm.get() shouldBe "$group:jxbrowser-win64-arm:$jxBrowserVersion"
+            graalvm.get() shouldBe "$group:jxbrowser-graalvm:$jxBrowserVersion"
             compose.get() shouldBe "$group:jxbrowser-compose:$jxBrowserVersion"
             linux64.get() shouldBe "$group:jxbrowser-linux64:$jxBrowserVersion"
             linuxArm.get() shouldBe "$group:jxbrowser-linux64-arm:$jxBrowserVersion"


### PR DESCRIPTION
This PR adds support for `jxbrowser-native-image`.

Issue: https://github.com/TeamDev-IP/JxBrowser/issues/4899